### PR TITLE
Support enums in .msg files

### DIFF
--- a/cmake/libucomm.cmake
+++ b/cmake/libucomm.cmake
@@ -5,7 +5,7 @@ macro(libucomm_wrap_msg outfile msg)
 	add_custom_command(
 		OUTPUT ${${outfile}}
 		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${msg}
-		COMMAND python ${LIBUCOMM_PARSE_PY}
+		COMMAND python2 ${LIBUCOMM_PARSE_PY}
 			${CMAKE_CURRENT_SOURCE_DIR}/${msg}
 			> ${${outfile}}
 	)

--- a/libucomm_parse.py
+++ b/libucomm_parse.py
@@ -71,8 +71,12 @@ class Enum:
 
 	def definition(self, indent_level = 0):
 		base_indent = '\t' * indent_level
-		code = [
-			base_indent + 'enum %s' % self.name,
+		code = []
+		if self.name:
+			code.append(base_indent + 'enum %s' % self.name)
+		else:
+			code.append(base_indent + 'enum')
+		code += [
 			base_indent + '{',
 			'\n'.join([base_indent + '\t' + e.definition() for e in self.entries]),
 			base_indent + '};'


### PR DESCRIPTION
Features:
- Supports enum definitions in .msg files, both on toplevel and scoped in structs/msgs.
- Make python2 explicitly the interpreter for the 'libucomm_wrap_msg' command. Ensures compatibility  with systems using python3 by default.

Caveats / Mentions:
- enums on the toplevel of the .msg file are generated inside the Proto<> class.
  If enums without any scope are wanted, the 'custom' command can still be used.
- enums inside of structs in the .msg file need to be defined before the members of
  the struct. Could be fixed with fiddling a bit more with pyparsing if wanted.
